### PR TITLE
Add celery ack late settings

### DIFF
--- a/deployment/docker-compose.yml
+++ b/deployment/docker-compose.yml
@@ -2,7 +2,7 @@ version: '2'
 services:
 
   rabbitmq:
-    image: library/rabbitmq
+    image: library/rabbitmq:3.6
     restart: on-failure
     network_mode: bridge
     ports:

--- a/src/headless/celeryconfig_sample.py
+++ b/src/headless/celeryconfig_sample.py
@@ -66,5 +66,11 @@ task_serializer = 'pickle'
 accept_content = {'pickle'}
 result_serializer = 'pickle'
 
+
+# Late ACK settings
+task_acks_late = True
+task_reject_on_worker_lost = True
+
+
 task_always_eager = ast.literal_eval(
     os.environ.get('TASK_ALWAYS_EAGER', 'False'))


### PR DESCRIPTION
Workaround to let celery do late ACK, so if the test fails, someone will pick it again.