### PR TITLE
Fix get_keywords doesn't return string if key is specified

### DIFF
--- a/src/headless/tasks/inasafe_analysis.py
+++ b/src/headless/tasks/inasafe_analysis.py
@@ -66,8 +66,10 @@ def get_keywords(layer_uri, keyword=None):
     :returns: Dictionary of keywords or value of key as string.
     :rtype: dict, basestring
     """
-    metadata = read_iso19115_metadata(layer_uri, keyword)
+    metadata = read_iso19115_metadata(layer_uri)
     clean_metadata(metadata)
+    if keyword:
+        return metadata[keyword]
     return metadata
 
 

--- a/src/headless/tasks/test/test_celery_task.py
+++ b/src/headless/tasks/test/test_celery_task.py
@@ -81,6 +81,13 @@ class TestHeadlessCeleryTask(unittest.TestCase):
             keywords['layer_purpose'], layer_purpose_exposure['key'])
         self.assertEqual(keywords['exposure'], exposure_place['key'])
 
+        # Test retrieve specific keyword
+        result = get_keywords.delay(
+            place_layer_uri, keyword='layer_purpose')
+        keyword = result.get()
+        self.assertIsNotNone(keyword)
+        self.assertEqual(keyword, layer_purpose_exposure['key'])
+
         pickled_keywords = pickle.dumps(keywords)
         new_keywords = pickle.loads(pickled_keywords)
         self.assertDictEqual(keywords, new_keywords)


### PR DESCRIPTION
Should handle if keyword is specified. It will return the value.